### PR TITLE
fix a few comment uppercase errors; add an explanation of x

### DIFF
--- a/jquery.easing.js
+++ b/jquery.easing.js
@@ -12,7 +12,7 @@ jQuery.easing['jswing'] = jQuery.easing['swing'];
 
 jQuery.extend( jQuery.easing,
 {
-	// t: current time, b: begInnIng value, c: change In value, d: duration
+	// x: value, t: current time, b: beginning value, c: change in value, d: duration
 	
 	def: 'easeOutQuad',
 	swing: function (x, t, b, c, d) {


### PR DESCRIPTION
A few comment `i`s were inappropriately uppercase (I suspect from a find/replace sentence case update)

Also I added a note about what `x` is for because of #6 